### PR TITLE
fixing the #user-name [h1] responsiveness.

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -149,7 +149,7 @@ nav a{
 }
 
 #user-name{
-    font-size: 48px;
+    font-size: clamp(36px,50%,48px);
     line-height: 0;
 }
 


### PR DESCRIPTION
Hi Dennis,

Hope you are doing well,

yesterday I was reading the article "5 things that ranked my website fast
" on your website on my mobile and I found a little bug with the website's CSS

here's a screenshot of the bug: 
![image](https://user-images.githubusercontent.com/37639473/231544738-d3052463-89ac-42e3-9dc2-7c3967632c89.png)

As you can see the h1 with your name is not responsive and the letters are scrambling, so I forked the repo and investigated it, it was not much just the font size needed to be smaller on mobile screens width but instead of doing a "Media Query" I did the most direct and simple solution a clamp function with an adjustable font-size and tested it, it's working perfectly with every screen width.

Old Code with Responsive Problem:
`#user-name {
    font-size: 48px;
    line-height: 0;
}`

Updated Code: 
`#user-name {
    font-size: clamp(36px,50%,48px);
    line-height: 0;
}`

Screenshot after the updated code:

![image](https://user-images.githubusercontent.com/37639473/231546230-16dc2878-e5ce-42b8-8454-47f1c4aa4b8a.png)

--------------------------------------------------------

Away from code, I want to say thanks for your great content I remember how I learned CSS-Flexbox from your video "CSS Flexbox Oversimplified", and away from technical videos, your other ones are very informative and high-quality content 
my favorite is "[Let Your Pain Motivate You](https://www.youtube.com/watch?v=yngo848avVg&t=49s)"

hope you are coming back with great content and wish you the best

Sincerely,
Mahmoud